### PR TITLE
Update batch_comp.py

### DIFF
--- a/inversionson/components/batch_comp.py
+++ b/inversionson/components/batch_comp.py
@@ -210,9 +210,9 @@ class BatchComponent(Component):
             for param in parameters:
                 indices.append(dim_labels.index(param))
             # relevant_grad = grad[:, indices, :]
-        return self._sum_relevant_values(
-            grad=grad[()], param_ind=indices, unique_indices=unique_indices
-        )
+            return self._sum_relevant_values(
+                grad=grad[()], param_ind=indices, unique_indices=unique_indices
+            )
 
     def _remove_individual_grad_from_full_grad(
         self, full_grad: np.ndarray, event: str, unique_indices=np.ndarray,


### PR DESCRIPTION
Avoid a HDF5 dataset-related error when calling "_get_vector_of_values"
Please see the link: 
https://stackoverflow.com/questions/36651895/cant-access-returned-h5py-object-instance