### PR TITLE
Update storyteller.py

### DIFF
--- a/inversionson/components/storyteller.py
+++ b/inversionson/components/storyteller.py
@@ -197,7 +197,7 @@ class StoryTellerComponent(Component):
         if iteration.startswith("it0000_model"):
             iteration_number = 0
         else:
-            iteration_number = int(iteration.split("_")[0][2:].strip("0"))
+            iteration_number = int(iteration.split("_")[0][2:].lstrip("0"))
         self.markdown.add_header(
             header_style=2, text=f"Iteration: {iteration_number}"
         )


### PR DESCRIPTION
When iteration = "it00X0_model_TrRadius_XXX", the strip() method returns "X" rather than "X0". The lstrip() method can return correct result.